### PR TITLE
Add name-value pairs syntax to construct

### DIFF
--- a/construct/BCT_tree.m
+++ b/construct/BCT_tree.m
@@ -34,21 +34,22 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function tree = BCT_tree (BCT, options)
+function tree = BCT_tree (varargin)
 
-if (nargin < 1) || isempty (BCT)
-    BCT      = [1 2 1 0 2 0 0];
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('BCT', [1 2 1 0 2 0 0])
+p.addParameter('w', false)
+p.addParameter('s', false)
+p.addParameter('dA', false)
+pars = parseArgs(p, varargin, {'BCT'}, {'w', 's', 'dA'});
+%==============================================================================%
 
-if (nargin < 2) || isempty (options)
-    options  = '';
-end
-
-if ~isBCT_tree (BCT)
+if ~isBCT_tree (pars.BCT)
     error    ('input vector is not BCT conform');
 end
 
-zlen             = length (BCT);
+zlen             = length (pars.BCT);
 STACK            = 1;
 POINTER          = 1;
 i1               = 0;
@@ -58,13 +59,13 @@ for counter      = 1 : zlen
         dA       (counter, i1) = 1;
     end
     i1           = counter;
-    if BCT (counter) == 0
+    if pars.BCT (counter) == 0
         % POP ART
         ART      = STACK (POINTER);
         POINTER  = POINTER - 1;
         i1       = ART;
     end
-    if BCT (counter) == 2
+    if pars.BCT (counter) == 2
         PC       = counter;
         % PUSH PC
         POINTER  = POINTER + 1;
@@ -76,18 +77,18 @@ tree             = [];
 tree.dA          = dA;
 
 % add metrics if not explicitly unwanted
-if ~contains     (options, '-dA')
-    if contains  (options, '-w')
+if ~pars.dA
+    if pars.w
         [~, tree] = xdend_tree (tree, '-w');
     else
         [~, tree] = xdend_tree (tree, 'none');
     end
 end
 
-if contains      (options, '-s') % show option
+if pars.s % show option
     clf;
     hold         on;
-    if contains  (options, '-dA')
+    if pars.dA
         dendrogram_tree (tree, [], PL_tree (tree));
         axis     off;
     else

--- a/construct/allBCTs_tree.m
+++ b/construct/allBCTs_tree.m
@@ -34,46 +34,44 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function [BCTs, BCTtrees] = allBCTs_tree (N, options)
+function [BCTs, BCTtrees] = allBCTs_tree (varargin)
 
-if (nargin < 1) || isempty (N)
-    % {DEFAULT: eight nodes}
-    N        = 8;
-end
-
-if (nargin < 2) || isempty (options)
-    % {DEFAULT: waitbar}
-    options  = '-w';
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('N', 8)
+p.addParameter('w', true)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {'N'}, {'w', 's'});
+%==============================================================================%
 
 MT               = [];
-if contains       (options, '-w')     % waitbar option: initialization
-    if ((3^N) - 1) > 19998
+if pars.w     % waitbar option: initialization
+    if ((3^pars.N) - 1) > 19998
         HW       = waitbar (0, 'trying out BCT strings...');
         set      (HW, 'Name', '..PLEASE..WAIT..YEAH..');
     end
 end
-for counter      = 0 : (3^N) - 1
+for counter      = 0 : (3^pars.N) - 1
     % waitbar option: update:
-    if contains   (options, '-w')
+    if pars.w
         if  (mod (counter, 20000) == 19999)
-            waitbar (counter / ((3^N) - 1), HW);
+            waitbar (counter / ((3^pars.N) - 1), HW);
         end
     end
     % create all possible strings with B, C and T:
-    BCT          = mod (floor (counter ./ (3.^(N - 1 : -1 : 0))), 3);
+    BCT          = mod (floor (counter ./ (3.^(pars.N - 1 : -1 : 0))), 3);
     if isBCT_tree (BCT)
         % if they are BCT conform then add them to the list:
         MT       = [MT; BCT];
     end
 end
-if contains       (options, '-w')     % waitbar option: close
-    if ((3^N) - 1) > 19998
+if pars.w     % waitbar option: close
+    if ((3^pars.N) - 1) > 19998
         close    (HW);
     end
 end
 
-MT2              = zeros (size (MT, 1), N);
+MT2              = zeros (size (MT, 1), pars.N);
 for counter      = 1 : size (MT, 1)
     BCT          = MT (counter, :);
     tree         = BCT_tree  (BCT,  '-dA'); % create tree from BCT string
@@ -82,27 +80,22 @@ for counter      = 1 : size (MT, 1)
 end
 
 BCTs             = unique (MT2, 'rows'); % get rid of duplicates
-if (nargout > 1) || contains (options, '-s')
+if (nargout > 1) || pars.s
     BCTtrees     = cell (1,  size (BCTs, 1));
     for counter  = 1 : size (BCTs, 1)
         BCTtrees{counter} = BCT_tree (BCTs (counter, :));
     end
 end
 
-if contains       (options, '-s') % show option
+if pars.s % show option
     clf; hold on;
     dd           = spread_tree (BCTtrees);
     for counter  = 1 : length  (BCTtrees)
         pointer_tree (dd{counter}, 1, [], [], [], '-o');
         plot_tree    (BCTtrees{counter}, [] , dd{counter});
     end
-    text         (0, 50, ['all BCT trees - ' (num2str (N)) ' nodes']);
+    text         (0, 50, ['all BCT trees - ' (num2str (pars.N)) ' nodes']);
     view         (2);
     axis         image off
 end
-
-
-
-
-
 

--- a/construct/allBTs_tree.m
+++ b/construct/allBTs_tree.m
@@ -36,40 +36,38 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function [BTs, BTtrees] = allBTs_tree (N, options)
+function [BTs, BTtrees] = allBTs_tree (varargin)
 
-if (nargin < 1) || isempty (N)
-    % {DEFAULT: 15 nodes}
-    N        = 15;
-end
-
-if (nargin < 2) || isempty (options)
-    % {DEFAULT: waitbar}
-    options  = '-w';
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('N', 15)
+p.addParameter('w', true)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {'N'}, {'w', 's'});
+%==============================================================================%
 
 MT               = [];
-if contains      (options, '-w')     % waitbar option: initialization
+if pars.w     % waitbar option: initialization
     HW           = waitbar (0, 'trying out BCT strings...');
     set          (HW, 'Name', '..PLEASE..WAIT..YEAH..');
 end
-for counter      = 0 : (2^N) - 1
+for counter      = 0 : (2^pars.N) - 1
     % waitbar option: update
-    if contains  (options, '-w') && (mod (counter, 1000) == 0)  
-        waitbar  (counter / ((2^N) - 1), HW);
+    if pars.w && (mod (counter, 1000) == 0)  
+        waitbar  (counter / ((2^pars.N) - 1), HW);
     end
     % create all possible strings with B and T:
-    BT           = 2 * mod (floor (counter ./ (2.^(N - 1 : -1 : 0))), 2);
+    BT           = 2 * mod (floor (counter ./ (2.^(pars.N - 1 : -1 : 0))), 2);
     if isBCT_tree (BT)
         % if they are BT conform then add them to the list:
         MT       = [MT; BT];
     end
 end
-if contains      (options, '-w')     % waitbar option: close
+if pars.w     % waitbar option: close
     close        (HW);
 end
 
-MT2              = zeros (size (MT, 1), N);
+MT2              = zeros (size (MT, 1), pars.N);
 for counter      = 1 : size (MT, 1)
     BT           = MT (counter, :);
     tree         = BCT_tree  (BT,   '-dA'); % create tree from BCT string
@@ -78,14 +76,14 @@ for counter      = 1 : size (MT, 1)
 end
 
 BTs              = unique (MT2, 'rows'); % get rid of duplicates
-if (nargout > 1) || ~isempty (contains (options, '-s'))
+if (nargout > 1) || pars.s
     BTtrees      = cell (1,  size (BTs, 1));
     for counter  = 1 : size (BTs, 1)
         BTtrees {counter} = BCT_tree (BTs (counter, :));
     end
 end
 
-if contains      (options, '-s') % show option
+if pars.s % show option
     clf;
     hold         on;
     dd           = spread_tree (BTtrees);
@@ -93,7 +91,7 @@ if contains      (options, '-s') % show option
         plot_tree    (BTtrees {counter}, [] , dd {counter});
         pointer_tree (dd {counter});
     end
-    text         (0, 50, ['all BCT trees - ' num2str(N) ' nodes']);
+    text         (0, 50, ['all BCT trees - ' num2str(pars.N) ' nodes']);
     view         (2);
     axis         equal off
 end

--- a/construct/cap_tree.m
+++ b/construct/cap_tree.m
@@ -105,7 +105,7 @@ if contains (options, '-a')
    tree.R (idpar (indaxon)) = find (strcmp (tree.rnames, 'axon'));
 end
 
-if contain       (options, '-s')
+if contains       (options, '-s')
     clf; hold on;
     HP           = plot_tree (intree);
     set          (HP, 'facealpha', .5);

--- a/construct/clean_tree.m
+++ b/construct/clean_tree.m
@@ -36,17 +36,17 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function tree = clean_tree (intree, radius, options)
+function tree = clean_tree (intree, varargin)
 
 ver_tree (intree); % verify that input is a tree structure
 
-if (nargin < 2) || isempty (radius)
-    radius   = 1;
-end
-
-if (nargin < 3) || isempty (options)
-    options  = '-w';
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('radius', 1)
+p.addParameter('w', true)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {'radius'}, {'w', 's'});
+%==============================================================================%
 
 % sort tree to be BCT conform, heavy parts left:
 tree             = sort_tree (intree, '-LO');
@@ -60,7 +60,7 @@ iBpar            = [];
 idpar            = idpar_tree (tree);
 IFFER            = [];
 if length (iT)   > 1
-    if contains   (options, '-w') % waitbar option: initialization
+    if pars.w % waitbar option: initialization
         if length (iT) > 499
             HW   = waitbar (0, 'cleaning the tree...');
             set  (HW, 'Name', '..PLEASE..WAIT..YEAH..');
@@ -68,7 +68,7 @@ if length (iT)   > 1
     end
     for counter  = 1 : length (iT)
         % waitbar option: update:
-        if contains (options, '-w')
+        if pars.w
             if   (mod (counter, 500) == 0)
                  waitbar (counter / length (iT), HW);
             end
@@ -79,18 +79,18 @@ if length (iT)   > 1
         idbpar   = idpar (ibranch (1)); % direct parent branch point
         if ~ismember (idbpar, iBpar) && ...
                 ~isempty (setdiff (find (eucl_tree (tree, iT (counter)) < ...
-                (D / 2 + radius / 2)), ibranch))
+                (D / 2 + pars.radius / 2)), ibranch))
             iBpar  = [iBpar idbpar];
             IFFER  = [IFFER ibranch];
         end
         if ~ismember (idbpar, iBpar) && ...
                 ~isempty (ibranch) && ...
-                (sum (len (ibranch)) < radius)
+                (sum (len (ibranch)) < pars.radius)
             iBpar  = [iBpar idbpar];
             IFFER  = [IFFER ibranch];
         end
     end
-    if contains   (options, '-w') % waitbar option: close
+    if pars.w % waitbar option: close
         if length (iT) > 499
             close (HW);
         end
@@ -101,7 +101,7 @@ if ~isempty      (IFFER)
     tree         = delete_tree (tree, IFFER); % delete all unwanted points
 end
 
-if contains       (options, '-s')
+if pars.s
     clf;
     hold         on;
     plot_tree    (intree, [],      [], [], [], '-3l');

--- a/construct/clone_tree.m
+++ b/construct/clone_tree.m
@@ -22,7 +22,7 @@
 % - bf       ::number between 0 .. 1: balancing factor
 %     {DEFAULT: 0.4}
 % - options  ::string:
-%     '-2d'  : 2D clones
+%     '-dim2': 2D clones (Careful, used to be called '-2d')
 %     '-s'   : show plot
 %     '-w'   : with waitbar
 %     {DEFAULT '-w'}
@@ -42,20 +42,20 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function ctrees = clone_tree (intrees, num, bf, options)
+function ctrees = clone_tree (intrees, varargin)
 
-if (nargin < 2) || isempty (num)
-    % {DEFAULT number of trees: one}
-    num      = 1;
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('num', 1)
+p.addParameter('bf', 0.4)
+p.addParameter('dim2', false)
+p.addParameter('w', true)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {'num', 'bf'}, {'dim2', 'w', 's'});
+%==============================================================================%
 
-if (nargin < 3) || isempty (bf)
-    % {DEFAULT balancing factor (see "MST_tree")}
-    bf       = 0.4;
-end
-
-if (nargin < 4) || isempty (options)
-    options  = '-w';
+if ~iscell(intrees)
+    intrees = {intrees};
 end
 
 spanning         = gscale_tree   (intrees);
@@ -67,16 +67,16 @@ Rother           = find ( ...
     ~strcmp (spanning.regions, 'axon')   & ...
     ~strcmp (spanning.regions, 'soma'));
 
-if contains      (options, '-w') % waitbar option: initialization
+if pars.w % waitbar option: initialization
     HW           = waitbar (0, 'creating clones one by one...');
     set          (HW, 'Name', '..PLEASE..WAIT..YEAH..');
 end
 
 % store synthetic trees:
-ctrees           = cell (1, num);
-for counterN     = 1 : num
-    if contains  (options, '-w') % waitbar option: update
-        waitbar  (counterN / num, HW);
+ctrees           = cell (1, pars.num);
+for counterN     = 1 : pars.num
+    if pars.w % waitbar option: update
+        waitbar  (counterN / pars.num, HW);
     end
     if ~isempty  (Rsoma)
         maxD     = [];
@@ -98,7 +98,7 @@ for counterN     = 1 : num
             +        mean (spanning.ylims{Rsoma}(:, 1))); ...
             (randn * std  (spanning.ylims{Rsoma}(:, 2)) ...
             +        mean (spanning.ylims{Rsoma}(:, 2)))];
-        if ~contains (options, '-2d')
+        if ~pars.dim2
             ZL   = [ ...
                 (randn * std  (spanning.zlims{Rsoma}(:, 1)) ...
                 +        mean (spanning.zlims{Rsoma}(:, 1))); ...
@@ -222,7 +222,7 @@ for counterN     = 1 : num
         [XR, YR, ZR]  = rpoints_tree (M, 4 * N, [], dX, dY, dZ, 0, 'none');
         % try out one tree with N points
         [tree1, indx] = MST_tree ({soma}, ...
-            XR (1 : N), YR (1 : N), ZR (1 : N), bf , ...
+            XR (1 : N), YR (1 : N), ZR (1 : N), pars.bf , ...
             10000, 150000, [], '-b');
         iNEW     = zeros (size (tree1.dA, 1), 1);
         iNEW (indx (indx (:, 2) ~= 0, 2)) = 1;
@@ -235,7 +235,7 @@ for counterN     = 1 : num
             NN   = round (N * 3.5);
         end
         tree     = MST_tree ({soma}, ...
-            XR (1 : NN), YR (1 : NN), ZR (1 : NN), bf ,...
+            XR (1 : NN), YR (1 : NN), ZR (1 : NN), pars.bf ,...
             10000, 150000, [], '-b');
         idpar    = idpar_tree (tree);
         % index at which the primary dendrite is attached (hopefully):
@@ -260,7 +260,7 @@ for counterN     = 1 : num
         end
         [XR, YR, ZR]  = rpoints_tree (M, 4 * N, [], dX, dY, dZ, 0, 'none');
         [tree1, indx] = MST_tree ({subtree}, ...
-            XR (1 : N), YR (1 : N), ZR (1 : N), bf, ...
+            XR (1 : N), YR (1 : N), ZR (1 : N), pars.bf, ...
             10000, 150000, [], '-b');
         iNEW     = zeros (size (tree1.dA, 1), 1);
         iNEW (indx (indx (:, 2) ~= 0, 2)) = 1;
@@ -270,7 +270,7 @@ for counterN     = 1 : num
             NN   = round (N * 3.5);
         end
         subtree  = MST_tree ({subtree}, ...
-            XR (1 : NN), YR (1 : NN), ZR (1 : NN), bf ,...
+            XR (1 : NN), YR (1 : NN), ZR (1 : NN), pars.bf ,...
             10000, 150000, [], '-b');
         subtree.R (subtree.R == 1) = ...
             subtree.R (subtree.R == 1) * 0 + ...
@@ -370,7 +370,7 @@ for counterN     = 1 : num
             [XR, YR, ZR] = rpoints_tree ( ...
                 M, 4 * N, [], dX, dY, dZ, 0, 'none');
             [tree1, indx] = MST_tree ({tree}, ...
-                XR (1 : N), YR (1 : N), ZR (1 : N), bf, ...
+                XR (1 : N), YR (1 : N), ZR (1 : N), pars.bf, ...
                 10000, 150000, [], '-b');
             iNEW     = zeros (size (tree1.dA, 1), 1);
             iNEW (indx (indx (:, 2) ~= 0, 2)) = 1;
@@ -380,7 +380,7 @@ for counterN     = 1 : num
                 NN   = round (N * 3.5);
             end
             tree     = MST_tree ({tree}, ...
-                XR (1 : NN), YR (1 : NN), ZR (1 : NN), bf, ...
+                XR (1 : NN), YR (1 : NN), ZR (1 : NN), pars.bf, ...
                 10000, 150000, [], '-b');
             tree.R (tree.R == 1) = ...
                 tree.R (tree.R == 1) * 0 + ...
@@ -431,18 +431,14 @@ for counterN     = 1 : num
     ctrees{counterN}   = btree;
 end
 
-if contains      (options, '-w') % waitbar option: close
+if pars.w % waitbar option: close
     close        (HW);
 end
 
-if contains      (options, '-s') % waitbar option: close
+if pars.s
     clf;
     hold         on;
-    if length    (intrees) > 1
-        plot_tree (intrees{1});
-    else
-        plot_tree (intrees);
-    end
+    plot_tree    (intrees{1});
     plot_tree    (ctrees{1}, [1 0 0]);
     HP (1)       = plot (1, 1, 'k-');
     HP (2)       = plot (1, 1, 'r-');

--- a/construct/cplotter.m
+++ b/construct/cplotter.m
@@ -23,7 +23,7 @@
 %
 % Example
 % -------
-% c          = hull_tree (sample_tree, 5, [], [], [], '-2d');
+% c          = hull_tree (sample_tree, 5, [], [], [], '-dim2');
 % cplotter   (c);
 %
 % See also hull_tree cpoints
@@ -32,20 +32,18 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function HP  = cplotter (c, color, DD)
+function HP  = cplotter (c, varargin)
 
-if (nargin < 2) || isempty (color)
-    % {DEFAULT color: black}
-    color    = [0 0 0];
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('color', [0 0 0])
+p.addParameter('DD', [0 0 0])
+pars = parseArgs(p, varargin, {'color', 'DD'}, {});
+%==============================================================================%
 
-if (nargin < 3) || isempty (DD)
-    % {DEFAULT 3-tupel: no spatial displacement from the root}
-    DD       = [0 0 0];
-end
-if length (DD) < 3
+if length (pars.DD) < 3
     % append 3-tupel with zeros:
-    DD       = [DD (zeros (1, 3 - length (DD)))];
+    pars.DD       = [pars.DD (zeros (1, 3 - length (pars.DD)))];
 end
 
 hold             on;
@@ -56,16 +54,12 @@ while (iic  < size (c, 1))
     ic           = c (iic, 2);
     CC           = c (iic + 1 : iic + ic, :);
     HP (counter) = plot3 ( ...
-        CC (:, 1) + DD (1), ...
-        CC (:, 2) + DD (2), ...
-        ones (size (CC, 1), 1) .* DD (3), 'k');
+        CC (:, 1) + pars.DD (1), ...
+        CC (:, 2) + pars.DD (2), ...
+        ones (size (CC, 1), 1) .* pars.DD (3), 'k');
     iic          = iic + ic + 1;
     counter      = counter + 1;
 end
 set              (HP, ...
-    'color',                   color);
-
-
-
-
+    'color',                   pars.color);
 

--- a/construct/dscam_tree.m
+++ b/construct/dscam_tree.m
@@ -26,22 +26,20 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function tree = dscam_tree (intree, iterations, options)
+function tree = dscam_tree (intree, varargin)
 
-% default num iterations
-if (nargin <2)||isempty(iterations)
-    iterations = length(intree.X)*5;
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('iterations', length(intree.X)*5)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {'iterations'}, {'s'});
+%==============================================================================%
 
-if (nargin<3)||isempty(options)
-    options = 'none';
-end
-
-tree         = intree;
+tree             = intree;
 
 %How far should a node be moved to closest node?
 movePercent      = 0.1;
-for counter      = 1 : iterations
+for counter      = 1 : pars.iterations
 
     % create index vector
     iVector 	 = true (length (tree.X), 1);
@@ -94,7 +92,7 @@ for counter      = 1 : iterations
     tree.Z (iChild) = tree.Z (iChild) + XYZMove (3);
 end
 
-if contains      (options, '-s')
+if pars.s
     clf;
     hold         on;
     plot_tree    (intree, [],      [], [], [], '-3l');

--- a/construct/gscale_tree.m
+++ b/construct/gscale_tree.m
@@ -39,11 +39,14 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function [spanning, ctrees] = gscale_tree (intrees, options)
+function [spanning, ctrees] = gscale_tree (intrees, varargin)
 
-if (nargin < 2) || isempty (options)
-    options  = 'none';
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('s', false)
+p.addParameter('w', false)
+pars = parseArgs(p, varargin, {}, {'s', 'w'});
+%==============================================================================%
 
 for counterT     = 1 : length (intrees)
     intrees {counterT} = tran_tree (intrees{counterT});
@@ -68,14 +71,14 @@ spanning.zmass   = cell   (1, lenr);
 spanning.iR      = cell   (1,    1);
 spanning.nBT     = cell   (1,    1);
 dR               = zeros  (1, lenr); % empty region flag
-if contains      (options, '-w') % waitbar option: initialization
+if pars.w % waitbar option: initialization
     HW           = waitbar (0, ...
         'scanning spanning fields region by region...');
     set          (HW, ...
         'Name',                '..PLEASE..WAIT..YEAH..');
 end
 for counterR     = 1 : length (spanning.regions)
-    if contains  (options, '-w') % waitbar option: update
+    if pars.w % waitbar option: update
         waitbar  (counterR / length (spanning.regions), HW);
     end
     flag         = 0;
@@ -179,7 +182,7 @@ end
 % parameters:
 qtrees           = cell (1, 1);
 for counterT     = 1 : length (intrees)
-    if contains  (options, '-w') % waitbar option: update
+    if pars.w % waitbar option: update
         waitbar  (counterT / length (intrees), HW);
     end
     qtrees{counterT} = quaddiameter_tree (intrees {counterT});
@@ -189,7 +192,7 @@ end
 % (can be expanded):
 spanning.wriggles = zeros (length (intrees), 2);
 for counterT     = 1 : length (intrees)
-    if contains  (options, '-w') % waitbar option: update
+    if pars.w % waitbar option: update
         waitbar  (counterT / length (intrees), HW);
     end
     tree         = intrees{counterT};
@@ -253,7 +256,7 @@ spanning.Y       = cell (1, 1);
 spanning.Z       = cell (1, 1);
 spanning.qdiam   = cell (1, 1);
 for counterR     = 1 : length (spanning.regions)
-    if contains  (options, '-w') % waitbar option: update
+    if pars.w % waitbar option: update
         waitbar  (counterR / length (spanning.regions), HW);
     end
     spanning.qdiam{counterR} = [];
@@ -329,11 +332,11 @@ for counterR     = 1 : lenr
     spanning.stdnBT (counterR) = std  (cat (2, spanning.nBT{counterR}{:}));
 end
 
-if contains      (options, '-w') % waitbar option: close
+if pars.w % waitbar option: close
     close        (HW);
 end
 
-if contains      (options, '-s')
+if pars.s
     clf;
     hold         on;
     cX           = [ ...

--- a/construct/quaddiameter_tree.m
+++ b/construct/quaddiameter_tree.m
@@ -1,7 +1,7 @@
 % QUADDIAMETER_TREE   Map quadratic diameter tapering to tree.
 % (trees package)
 %
-% tree = quaddiameter_tree (intree, scale, offset, options, P, ldend)
+% tree = quaddiameter_tree (intree, scale, offset, P, ldend, options)
 % -------------------------------------------------------------------
 %
 % Applies a quadratic decaying diameter on a given tree structure. P
@@ -39,7 +39,7 @@
 %
 % Example
 % -------
-% quaddiameter_tree (sample_tree, [], [], '-s')
+% quaddiameter_tree (sample_tree, [], [], [], [], '-s')
 %
 % See also
 % Uses Pvec_tree ipar_tree T_tree ver_tree dA D
@@ -47,35 +47,33 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function  varargout = quaddiameter_tree (intree, scale, offset, options, ...
-    P, ldend)
+function  tree = quaddiameter_tree (intree, varargin)
 
 ver_tree     (intree); % verify that input is a tree structure
 % use full tree for this function
 tree         = intree;
 
-if (nargin < 2) || isempty (scale)
-    % {DEFAULT: 50 % of if the branch was on its own}
-    scale    = 0.5;
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('scale', 0.5)
+p.addParameter('offset', 0.5)
+p.addParameter('P', [])
+p.addParameter('ldend', [])
+p.addParameter('s', false)
+p.addParameter('w', false)
+pars = parseArgs(p, varargin, {'scale', 'offset', 'P', 'ldend'}, {'s', 'w'});
+%==============================================================================%
 
-if (nargin < 3) || isempty (offset)
-    % {DEFAULT: + 0.5 um ofif the branch was on its own}
-    offset   = 0.5;
-end
+P            = pars.P;
+ldend        = pars.ldend;
 
-if (nargin < 4) || isempty (options)
-    % {DEFAULT: no option}
-    options  = '';
-end
-
-if (nargin < 5) || isempty (P)
+if isempty (P)
     % {DEFAULT: parameters calculated for optimal current transfer for
     % branches on their own}
     load     quaddiameter_P P
 end
 
-if (nargin < 6) || isempty (ldend)
+if isempty (ldend)
     % {DEFAULT: length values of branches for which P is given
     % quaddiameter_tree uses the P whos ldend is closest to the
     % path length for each path to termination point}
@@ -91,7 +89,7 @@ ipari        = [(1 : N)' (ipar_tree (tree))];
 % parent index paths but only for termination nodes:
 ipariT       = ipari (T_tree (tree), :);
 
-if contains  (options, '-w')      % waitbar option: initialization
+if pars.w      % waitbar option: initialization
     HW       = waitbar ( ...
         0,                     'calculating quad diameter...');
     set      (HW, ...
@@ -100,7 +98,7 @@ end
 
 Ds               = zeros (size (ipariT));
 for counter      = 1    : size (ipariT, 1)
-    if contains   (options, '-w')    % waitbar option: update
+    if pars.w    % waitbar option: update
         if mod   (counter, 500) == 0
             waitbar (counter / size (ipariT, 1), HW);
         end
@@ -110,12 +108,12 @@ for counter      = 1    : size (ipariT, 1)
     pathh        = Plen   (iipariT);
     % find which ldend is closest to path length:
     [~, i2]      = min    ((pathh (end) - ldend).^2);
-    quadpathh    = polyval (P (i2, :), pathh) .* scale;
+    quadpathh    = polyval (P (i2, :), pathh) .* pars.scale;
     % apply the diameters:
     Ds (counter, 1 : length (quadpathh)) = fliplr (quadpathh);
 end
 
-if contains      (options, '-w')      % waitbar option: close
+if pars.w      % waitbar option: close
     close        (HW);
 end
 
@@ -126,9 +124,9 @@ for counter      = 1 : N
     tree.D (counter)   = mean (Ds (iR));
 end
 
-tree.D           = tree.D + offset; % add offset diameter
+tree.D           = tree.D + pars.offset; % add offset diameter
 
-if contains      (options, '-s') % show option
+if pars.s % show option
     clf; hold on;
     plot_tree    (intree, [0 0 0]);
     plot_tree    (tree,   [1 0 0]);

--- a/construct/quadfit_tree.m
+++ b/construct/quadfit_tree.m
@@ -32,16 +32,18 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function  [P0, tree] = quadfit_tree (intree, options)
+function  [P0, tree] = quadfit_tree (intree, varargin)
 
 ver_tree     (intree); % verify that input is a tree structure
 
-if (nargin < 2) || isempty (options)
-    % {DEFAULT: no option}
-    options  = '';
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('w', false)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {}, {'w', 's'});
+%==============================================================================%
 
-if contains  (options, '-w')   % waitbar option: initialization
+if pars.w   % waitbar option: initialization
     HW       = waitbar (0.3, 'fitting quad diameter...');
     set      (HW, ...
         'Name',                '..PLEASE..WAIT..YEAH..');
@@ -49,15 +51,15 @@ end
 
 P0               = fminsearch (@(P) qfit (P, intree), rand (1, 2));
 
-if contains      (options, '-w')   % waitbar option: close
+if pars.w   % waitbar option: close
     close        (HW);
 end
 
-if (nargout > 1) || contains (options, '-s')
-    tree         = quaddiameter_tree (intree, P0 (1), P0 (2), 'none');
+if (nargout > 1) || pars.s
+    tree         = quaddiameter_tree (intree, P0 (1), P0 (2), [], [], 'none');
 end
 
-if contains      (options, '-s') % show option
+if pars.s % show option
     clf;
     hold         on;
     plot_tree    (tree,   [1 0 0]);

--- a/construct/rpoints_tree.m
+++ b/construct/rpoints_tree.m
@@ -54,45 +54,69 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function [X, Y, Z, HP] = rpoints_tree (M, N, c, x, y, z, thr, options)
+function [X, Y, Z, HP] = rpoints_tree (varargin)
 
-if (nargin < 1) || isempty (M)
-    M        = [];
-    % possibly:
-    % sr     = 25; % sets the bin size for sampling the density
-    % % calculates the density matrix M at points (dX, dY):
-    % [M, dX, dY] = gdens_tree (intree, ...
-    %    sr, B_tree (intree) | T_tree (intree));
-end
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+% possibly:
+% sr     = 25; % sets the bin size for sampling the density
+% % calculates the density matrix M at points (dX, dY):
+% [M, dX, dY] = gdens_tree (intree, ...
+%    sr, B_tree (intree) | T_tree (intree));
+p.addParameter('M', [])
+p.addParameter('N', 1000)
+p.addParameter('c', [])
+p.addParameter('x', [])
+p.addParameter('y', [])
+p.addParameter('z', [])
+p.addParameter('thr', [])
+p.addParameter('s', false)
+p.addParameter('w', true)
+pars = parseArgs(p, varargin, {'M', 'N', 'c', 'x', 'y', 'z', 'thr'}, {'s', 'w'});
+%==============================================================================%
 
-if (nargin < 2) || isempty (N)
-    N        = 1000;
-end
-
-if (nargin < 3) || isempty (c)
-    c        = [];
-end
-
-if (nargin < 7) || isempty (thr)
-    thr      = [];
-end
-
-if (nargin < 8) || isempty (options)
-    options  = '-w';
-end
+% if (nargin < 1) || isempty (M)
+%     M        = [];
+%     % possibly:
+%     % sr     = 25; % sets the bin size for sampling the density
+%     % % calculates the density matrix M at points (dX, dY):
+%     % [M, dX, dY] = gdens_tree (intree, ...
+%     %    sr, B_tree (intree) | T_tree (intree));
+% end
+% 
+% if (nargin < 2) || isempty (N)
+%     N        = 1000;
+% end
+% 
+% if (nargin < 3) || isempty (c)
+%     c        = [];
+% end
+% 
+% if (nargin < 7) || isempty (thr)
+%     thr      = [];
+% end
+% 
+% if (nargin < 8) || isempty (options)
+%     options  = '-w';
+% end
+M = pars.M;
+N = pars.N;
+x = pars.x;
+y = pars.y;
+z = pars.z;
 
 if ~isempty      (M)
-    if (nargin < 4) || isempty (x)
+    if isempty (x)
         % possibly go gdens_tree
         x        = 1 : size (M, 2);
     end
-    if (nargin < 5) || isempty (y)
+    if isempty (y)
         y        = 1 : size (M, 1);
     end
-    if (nargin < 6) || isempty (z)
+    if isempty (z)
         z        = 1 : size (M, 3);
     end
-    if contains  (options, '-w')
+    if pars.w
         HW       = waitbar (0, 'distributing points...');
         set      (HW, ...
             'Name',            '..PLEASE..WAIT..YEAH..');
@@ -106,7 +130,7 @@ if ~isempty      (M)
         r1       = zeros (length (R), 1);
         r2       = zeros (length (R), 1);
         for counter  = 1 : length (R)
-            if contains   (options, '-w')
+            if pars.w
                 if mod (counter, 5000) == 1
                     waitbar  (counter / length (R), HW);
                 end
@@ -130,7 +154,7 @@ if ~isempty      (M)
         r2       = zeros (length (R), 1);
         r3       = zeros (length (R), 1);
         for counter = 1 : length (R)
-            if contains (options, '-w')
+            if pars.w
                 if mod (counter, 5000) == 1
                     waitbar (counter / length (R), HW);
                 end
@@ -146,14 +170,14 @@ if ~isempty      (M)
         Y        = y (r1)' + (rand (N, 1) - 0.5) .* (diff (y (1 : 2)));
         Z        = z (r3)' + (rand (N, 1) - 0.5) .* (diff (z (1 : 2)));
     end
-    if contains  (options, '-w')
+    if pars.w
         close    (HW);
     end
 else % if no density matrix was defined do a fully homogeneous picking
-    if (nargin < 4) || isempty (x)
+    if isempty (x)
         x        = [-500 500];
     end
-    if (nargin < 5) || isempty (y)
+    if isempty (y)
         y        = x;
     end
     if diff (x) ~= diff (y)
@@ -166,11 +190,11 @@ else % if no density matrix was defined do a fully homogeneous picking
     Z            = zeros (N, 1);
 end
 
-if ~isempty      (c)
-    IN           = find (in_c (X, Y, c));
-    [PX, PY]     = cpoints (c);
+if ~isempty      (pars.c)
+    IN           = find (in_c (X, Y, pars.c));
+    [PX, PY]     = cpoints (pars.c);
     M            = eucdist (X (IN), PX, Y (IN), PY);
-    IN2          = min     (M, [], 2) > thr;
+    IN2          = min     (M, [], 2) > pars.thr;
     XR           = X;
     YR           = Y;
     X            = XR (IN (IN2));
@@ -178,11 +202,11 @@ if ~isempty      (c)
     Z            = zeros (length (Y), 1);
 end
 
-if contains      (options, '-s') % show option
+if pars.s % show option
     clf;
     hold         on;
-    if ~isempty  (c)
-        cplotter (c);
+    if ~isempty  (pars.c)
+        cplotter (pars.c);
     end
     HP           = plot3 (X, Y, Z, 'ko');
     set          (HP, ...

--- a/construct/soma_tree.m
+++ b/construct/soma_tree.m
@@ -39,34 +39,37 @@
 % the TREES toolbox: edit, generate, visualise and analyse neuronal trees
 % Copyright (C) 2009 - 2023  Hermann Cuntz
 
-function tree = soma_tree (intree, maxD, l, options)
+function tree = soma_tree (intree, varargin)
 
 ver_tree     (intree);
 tree         = intree;
 
-if (nargin < 2) || isempty (maxD)
-    maxD     = 30;
+%=============================== Parsing inputs ===============================%
+p = inputParser;
+p.addParameter('maxD', 30)
+p.addParameter('l', [])
+p.addParameter('r', false)
+p.addParameter('b', false)
+p.addParameter('s', false)
+pars = parseArgs(p, varargin, {'maxD', 'l'}, {'r', 'b', 's'});
+%==============================================================================%
+
+if isempty (pars.l)
+    pars.l       = 1.5 * pars.maxD;
 end
 
-if (nargin < 3) || isempty (l)
-    l        = 1.5 * maxD;
-end
-
-if (nargin < 4) || isempty (options)
-    options  = '';
-end
 
 Plen             = Pvec_tree (tree);
-indy             = find      (Plen < l / 2);
+indy             = find      (Plen < pars.l / 2);
 % % this used to be:
 % dmaxD        = max       (tree.D (indy), ...
 %     maxD / 4 * cos (pi * Plen (indy) / (l / 2)) + maxD / 4);
 
 dmaxD            = max       ( ...
     tree.D (indy), ...
-    maxD * cos (pi * Plen (indy) / l) );
+    pars.maxD * cos (pi * Plen (indy) / pars.l) );
 
-if contains (options, '-b')
+if pars.b
     flag         = 0;
     % check if branch point directly at soma..check if this branchpoint is
     % just the axon (angle should be wider than 90°):
@@ -91,14 +94,14 @@ end
 
 tree.D (indy)    = dmaxD;
 
-if contains (options, '-r')
+if pars.r
     if ~any (strcmp (intree.rnames,'soma'))
         tree.rnames  = [tree.rnames, 'soma'];
     end
     tree.R (indy)    = find (strcmp (tree.rnames, 'soma'));
 end
 
-if contains      (options, '-s')
+if pars.s
     clf;
     hold         on;
     HP           = plot_tree (intree);


### PR DESCRIPTION
- Fix bugs and in some functions in construct: - Add the missing the arguments in the call for quaddiameter_tree function inside quadfit_tree. - In clone_tree function, if one tree is given, put it in a cell array for the internal functions that expect a cell array of trees to work. Also update the plotting option to handle this.
- The options argument pushed to the last position in jitter_tree.